### PR TITLE
Make CypherCursor.GetRow() compatible with OPTIONAL MATCH

### DIFF
--- a/age/age.go
+++ b/age/age.go
@@ -237,7 +237,7 @@ func (c *CypherCursor) Next() bool {
 func (c *CypherCursor) GetRow() ([]Entity, error) {
 	var gstrs = make([]interface{}, c.columnCount)
 	for i := 0; i < c.columnCount; i++ {
-		gstrs[i] = new(string)
+		gstrs[i] = new(sql.NullString)
 	}
 
 	err := c.rows.Scan(gstrs...)
@@ -247,14 +247,17 @@ func (c *CypherCursor) GetRow() ([]Entity, error) {
 
 	entArr := make([]Entity, c.columnCount)
 	for i := 0; i < c.columnCount; i++ {
-		gstr := gstrs[i].(*string)
-		e, err := c.unmarshaler.unmarshal(*gstr)
-		if err != nil {
-			fmt.Println(i, ">>", gstr)
-			return nil, err
+		gstr := gstrs[i].(*sql.NullString)
+		if gstr.Valid {
+			e, err := c.unmarshaler.unmarshal(*gstr)
+			if err != nil {
+				fmt.Println(i, ">>", gstr)
+				return nil, err
+			}
+			entArr[i] = e
+		} else {
+			entArr[i] = nil
 		}
-
-		entArr[i] = e
 	}
 
 	return entArr, nil

--- a/age/age.go
+++ b/age/age.go
@@ -249,7 +249,7 @@ func (c *CypherCursor) GetRow() ([]Entity, error) {
 	for i := 0; i < c.columnCount; i++ {
 		gstr := gstrs[i].(*sql.NullString)
 		if gstr.Valid {
-			e, err := c.unmarshaler.unmarshal(*gstr)
+			e, err := c.unmarshaler.unmarshal(gstr.String)
 			if err != nil {
 				fmt.Println(i, ">>", gstr)
 				return nil, err


### PR DESCRIPTION
Scan() returns an error when attempting to read a NULL into a regular string, and need to guard unmarshal call by checking for a valid string to return expected nil value.