### PR TITLE
Correctly return control characters within query result strings

### DIFF
--- a/age/builder.go
+++ b/age/builder.go
@@ -221,7 +221,8 @@ func (v *UnmarshalVisitor) handleAnnotatedValue(anno string, ctx antlr.ParserRul
 
 func (v *UnmarshalVisitor) VisitStringValue(ctx *parser.StringValueContext) interface{} {
 	txt := ctx.GetText()
-	return strings.Trim(txt, "\"")
+	txt, _ = strconv.Unquote(txt)
+	return txt
 }
 
 func (v *UnmarshalVisitor) VisitIntegerValue(ctx *parser.IntegerValueContext) interface{} {


### PR DESCRIPTION
For example, if a string contains a newline (\n), it should not be returned as a literal backslash and a literal 'n'.